### PR TITLE
Add Composer with PHP8 autoload setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ rad.json
 *.flf
 #Test results file
 TestResults.xml
+
+# Composer
+vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "veekay/clean-code",
+    "description": "Clean Code in PHP",
+    "type": "library",
+    "require": {
+        "php": "^8.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Veekay\\CleanCode\\": "src/"
+        }
+    },
+    "license": "MIT"
+}

--- a/src/Hello.php
+++ b/src/Hello.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Veekay\CleanCode;
+
+class Hello
+{
+    public static function greet(): string
+    {
+        return "Hello, Clean Code!";
+    }
+}


### PR DESCRIPTION
## Summary
- initialize Composer configuration with PHP 8 requirement and PSR-4 autoloading
- create `src/` folder with sample `Hello` class
- update `.gitignore` for Composer artifacts

## Testing
- `composer --version` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408044e128832bb12b0941ecde2932